### PR TITLE
Add Cadence language

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1094,6 +1094,9 @@
 [submodule "vendor/grammars/vsc-fennel"]
 	path = vendor/grammars/vsc-fennel
 	url = https://github.com/kongeor/vsc-fennel
+[submodule "vendor/grammars/vscode-cadence"]
+	path = vendor/grammars/vscode-cadence
+	url = https://github.com/onflow/vscode-cadence.git
 [submodule "vendor/grammars/vscode-codeql"]
 	path = vendor/grammars/vscode-codeql
 	url = https://github.com/github/vscode-codeql

--- a/grammars.yml
+++ b/grammars.yml
@@ -958,6 +958,9 @@ vendor/grammars/vhdl:
 - source.vhdl
 vendor/grammars/vsc-fennel:
 - source.fnl
+vendor/grammars/vscode-cadence:
+- markdown.cadence.codeblock
+- source.cadence
 vendor/grammars/vscode-codeql:
 - source.ql
 vendor/grammars/vscode-cue:

--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -841,6 +841,14 @@ Cabal Config:
   codemirror_mime_type: text/x-haskell
   tm_scope: source.cabal
   language_id: 677095381
+Cadence:
+  type: programming
+  color: "#00ef8b"
+  ace_mode: text
+  tm_scope: source.cadence
+  extensions:
+  - ".cdc"
+  language_id: 270184138
 Cairo:
   type: programming
   color: "#ff4a48"

--- a/samples/Cadence/FlowFees.cdc
+++ b/samples/Cadence/FlowFees.cdc
@@ -1,0 +1,131 @@
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xFLOWTOKENADDRESS
+
+pub contract FlowFees {
+
+    // Event that is emitted when tokens are deposited to the fee vault
+    pub event TokensDeposited(amount: UFix64)
+
+    // Event that is emitted when tokens are withdrawn from the fee vault
+    pub event TokensWithdrawn(amount: UFix64)
+
+    // Event that is emitted when fees are deducted
+    pub event FeesDeducted(amount: UFix64, inclusionEffort: UFix64, executionEffort: UFix64)
+
+    // Event that is emitted when fee parameters change
+    pub event FeeParametersChanged(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCost: UFix64)
+
+    // Private vault with public deposit function
+    access(self) var vault: @FlowToken.Vault
+
+    pub fun deposit(from: @FungibleToken.Vault) {
+        let from <- from as! @FlowToken.Vault
+        let balance = from.balance
+        self.vault.deposit(from: <-from)
+        emit TokensDeposited(amount: balance)
+    }
+
+    /// Get the balance of the Fees Vault
+    pub fun getFeeBalance(): UFix64 {
+        return self.vault.balance
+    }
+
+    pub resource Administrator {
+        // withdraw
+        //
+        // Allows the administrator to withdraw tokens from the fee vault
+        pub fun withdrawTokensFromFeeVault(amount: UFix64): @FungibleToken.Vault {
+            let vault <- FlowFees.vault.withdraw(amount: amount)
+            emit TokensWithdrawn(amount: amount)
+            return <-vault
+        }
+
+        /// Allows the administrator to change all the fee parameters at once
+        pub fun setFeeParameters(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCost: UFix64) {
+            let newParameters = FeeParameters(surgeFactor: surgeFactor, inclusionEffortCost: inclusionEffortCost, executionEffortCost: executionEffortCost)
+            FlowFees.setFeeParameters(newParameters)
+        }
+
+        /// Allows the administrator to change the fee surge factor
+        pub fun setFeeSurgeFactor(_ surgeFactor: UFix64) {
+            let oldParameters = FlowFees.getFeeParameters()
+            let newParameters = FeeParameters(surgeFactor: surgeFactor, inclusionEffortCost: oldParameters.inclusionEffortCost, executionEffortCost: oldParameters.executionEffortCost)
+            FlowFees.setFeeParameters(newParameters)
+        }
+    }
+
+    /// A struct holding the fee parameters needed to calculate the fees
+    pub struct FeeParameters {
+        /// The surge factor is used to make transaction fees respond to high loads on the network
+        pub var surgeFactor: UFix64
+        /// The FLOW cost of one unit of inclusion effort. The FVM is responsible for metering inclusion effort.
+        pub var inclusionEffortCost: UFix64
+        /// The FLOW cost of one unit of execution effort. The FVM is responsible for metering execution effort.
+        pub var executionEffortCost: UFix64
+
+        init(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCost: UFix64){
+            self.surgeFactor = surgeFactor
+            self.inclusionEffortCost = inclusionEffortCost
+            self.executionEffortCost = executionEffortCost
+        }
+    }
+
+    /// Called when a transaction is submitted to deduct the fee
+    /// from the AuthAccount that submitted it
+    pub fun deductTransactionFee(_ acct: AuthAccount, inclusionEffort: UFix64, executionEffort: UFix64) {
+        var feeAmount = self.computeFees(inclusionEffort: inclusionEffort, executionEffort: executionEffort)
+
+        if feeAmount == UFix64(0) {
+            // If there are no fees to deduct, do not continue, 
+            // so that there are no unnecessarily emitted events
+            return
+        }
+
+        let tokenVault = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
+            ?? panic("Unable to borrow reference to the default token vault")
+
+        
+        if feeAmount > tokenVault.balance {
+            // In the future this code path will never be reached, 
+            // as payers that are under account minimum balance will not have their transactions included in a collection
+            //
+            // Currently this is not used to fail the transaction (as that is the responsibility of the minimum account balance logic),
+            // But is used to reduce the balance of the vault to 0.0, if the vault has less available balance than the transaction fees. 
+            feeAmount = tokenVault.balance
+        }
+        
+        let feeVault <- tokenVault.withdraw(amount: feeAmount)
+        self.vault.deposit(from: <-feeVault)
+
+        // The fee calculation can be reconstructed using the data from this event and the FeeParameters at the block when the event happened
+        emit FeesDeducted(amount: feeAmount, inclusionEffort: inclusionEffort, executionEffort: executionEffort)
+    }
+
+    pub fun getFeeParameters(): FeeParameters {
+        return self.account.copy<FeeParameters>(from: /storage/FlowTxFeeParameters) ?? panic("Error getting tx fee parameters. They need to be initialized first!")
+    }
+
+    access(self) fun setFeeParameters(_ feeParameters: FeeParameters) {
+        // empty storage before writing new FeeParameters to it
+        self.account.load<FeeParameters>(from: /storage/FlowTxFeeParameters)
+        self.account.save(feeParameters,to: /storage/FlowTxFeeParameters)
+        emit FeeParametersChanged(surgeFactor: feeParameters.surgeFactor, inclusionEffortCost: feeParameters.inclusionEffortCost, executionEffortCost: feeParameters.executionEffortCost)
+    }
+
+    
+    // compute the transaction fees with the current fee parameters and the given inclusionEffort and executionEffort
+    pub fun computeFees(inclusionEffort: UFix64, executionEffort: UFix64): UFix64 {
+        let params = self.getFeeParameters()
+        
+        let totalFees = params.surgeFactor * ( inclusionEffort * params.inclusionEffortCost + executionEffort * params.executionEffortCost )
+        return totalFees
+    }
+
+    init(adminAccount: AuthAccount) {
+        // Create a new FlowToken Vault and save it in storage
+        self.vault <- FlowToken.createEmptyVault() as! @FlowToken.Vault
+
+        let admin <- create Administrator()
+        adminAccount.save(<-admin, to: /storage/flowFeesAdmin)
+    }
+}

--- a/samples/Cadence/FlowToken.cdc
+++ b/samples/Cadence/FlowToken.cdc
@@ -1,0 +1,198 @@
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+
+pub contract FlowToken: FungibleToken {
+
+    // Total supply of Flow tokens in existence
+    pub var totalSupply: UFix64
+
+    // Event that is emitted when the contract is created
+    pub event TokensInitialized(initialSupply: UFix64)
+
+    // Event that is emitted when tokens are withdrawn from a Vault
+    pub event TokensWithdrawn(amount: UFix64, from: Address?)
+
+    // Event that is emitted when tokens are deposited to a Vault
+    pub event TokensDeposited(amount: UFix64, to: Address?)
+
+    // Event that is emitted when new tokens are minted
+    pub event TokensMinted(amount: UFix64)
+
+    // Event that is emitted when tokens are destroyed
+    pub event TokensBurned(amount: UFix64)
+
+    // Event that is emitted when a new minter resource is created
+    pub event MinterCreated(allowedAmount: UFix64)
+
+    // Event that is emitted when a new burner resource is created
+    pub event BurnerCreated()
+
+    // Vault
+    //
+    // Each user stores an instance of only the Vault in their storage
+    // The functions in the Vault and governed by the pre and post conditions
+    // in FungibleToken when they are called.
+    // The checks happen at runtime whenever a function is called.
+    //
+    // Resources can only be created in the context of the contract that they
+    // are defined in, so there is no way for a malicious user to create Vaults
+    // out of thin air. A special Minter resource needs to be defined to mint
+    // new tokens.
+    //
+    pub resource Vault: FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance {
+
+        // holds the balance of a users tokens
+        pub var balance: UFix64
+
+        // initialize the balance at resource creation time
+        init(balance: UFix64) {
+            self.balance = balance
+        }
+
+        // withdraw
+        //
+        // Function that takes an integer amount as an argument
+        // and withdraws that amount from the Vault.
+        // It creates a new temporary Vault that is used to hold
+        // the money that is being transferred. It returns the newly
+        // created Vault to the context that called so it can be deposited
+        // elsewhere.
+        //
+        pub fun withdraw(amount: UFix64): @FungibleToken.Vault {
+            self.balance = self.balance - amount
+            emit TokensWithdrawn(amount: amount, from: self.owner?.address)
+            return <-create Vault(balance: amount)
+        }
+
+        // deposit
+        //
+        // Function that takes a Vault object as an argument and adds
+        // its balance to the balance of the owners Vault.
+        // It is allowed to destroy the sent Vault because the Vault
+        // was a temporary holder of the tokens. The Vault's balance has
+        // been consumed and therefore can be destroyed.
+        pub fun deposit(from: @FungibleToken.Vault) {
+            let vault <- from as! @FlowToken.Vault
+            self.balance = self.balance + vault.balance
+            emit TokensDeposited(amount: vault.balance, to: self.owner?.address)
+            vault.balance = 0.0
+            destroy vault
+        }
+
+        destroy() {
+            FlowToken.totalSupply = FlowToken.totalSupply - self.balance
+        }
+    }
+
+    // createEmptyVault
+    //
+    // Function that creates a new Vault with a balance of zero
+    // and returns it to the calling context. A user must call this function
+    // and store the returned Vault in their storage in order to allow their
+    // account to be able to receive deposits of this token type.
+    //
+    pub fun createEmptyVault(): @FungibleToken.Vault {
+        return <-create Vault(balance: 0.0)
+    }
+
+    pub resource Administrator {
+        // createNewMinter
+        //
+        // Function that creates and returns a new minter resource
+        //
+        pub fun createNewMinter(allowedAmount: UFix64): @Minter {
+            emit MinterCreated(allowedAmount: allowedAmount)
+            return <-create Minter(allowedAmount: allowedAmount)
+        }
+
+        // createNewBurner
+        //
+        // Function that creates and returns a new burner resource
+        //
+        pub fun createNewBurner(): @Burner {
+            emit BurnerCreated()
+            return <-create Burner()
+        }
+    }
+
+    // Minter
+    //
+    // Resource object that token admin accounts can hold to mint new tokens.
+    //
+    pub resource Minter {
+
+        // the amount of tokens that the minter is allowed to mint
+        pub var allowedAmount: UFix64
+
+        // mintTokens
+        //
+        // Function that mints new tokens, adds them to the total supply,
+        // and returns them to the calling context.
+        //
+        pub fun mintTokens(amount: UFix64): @FlowToken.Vault {
+            pre {
+                amount > UFix64(0): "Amount minted must be greater than zero"
+                amount <= self.allowedAmount: "Amount minted must be less than the allowed amount"
+            }
+            FlowToken.totalSupply = FlowToken.totalSupply + amount
+            self.allowedAmount = self.allowedAmount - amount
+            emit TokensMinted(amount: amount)
+            return <-create Vault(balance: amount)
+        }
+
+        init(allowedAmount: UFix64) {
+            self.allowedAmount = allowedAmount
+        }
+    }
+
+    // Burner
+    //
+    // Resource object that token admin accounts can hold to burn tokens.
+    //
+    pub resource Burner {
+
+        // burnTokens
+        //
+        // Function that destroys a Vault instance, effectively burning the tokens.
+        //
+        // Note: the burned tokens are automatically subtracted from the
+        // total supply in the Vault destructor.
+        //
+        pub fun burnTokens(from: @FungibleToken.Vault) {
+            let vault <- from as! @FlowToken.Vault
+            let amount = vault.balance
+            destroy vault
+            emit TokensBurned(amount: amount)
+        }
+    }
+
+    init(adminAccount: AuthAccount) {
+        self.totalSupply = 0.0
+
+        // Create the Vault with the total supply of tokens and save it in storage
+        //
+        let vault <- create Vault(balance: self.totalSupply)
+        adminAccount.save(<-vault, to: /storage/flowTokenVault)
+
+        // Create a public capability to the stored Vault that only exposes
+        // the `deposit` method through the `Receiver` interface
+        //
+        adminAccount.link<&FlowToken.Vault{FungibleToken.Receiver}>(
+            /public/flowTokenReceiver,
+            target: /storage/flowTokenVault
+        )
+
+        // Create a public capability to the stored Vault that only exposes
+        // the `balance` field through the `Balance` interface
+        //
+        adminAccount.link<&FlowToken.Vault{FungibleToken.Balance}>(
+            /public/flowTokenBalance,
+            target: /storage/flowTokenVault
+        )
+
+        let admin <- create Administrator()
+        adminAccount.save(<-admin, to: /storage/flowTokenAdmin)
+
+        // Emit an event that shows that the contract was initialized
+        emit TokensInitialized(initialSupply: self.totalSupply)
+    }
+}

--- a/samples/Cadence/get_balance.cdc
+++ b/samples/Cadence/get_balance.cdc
@@ -1,0 +1,16 @@
+
+   
+// This script reads the balance field of an account's FlowToken Balance
+
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xFLOWTOKENADDRESS
+
+pub fun main(account: Address): UFix64 {
+
+    let vaultRef = getAccount(account)
+        .getCapability(/public/flowTokenBalance)
+        .borrow<&FlowToken.Vault{FungibleToken.Balance}>()
+        ?? panic("Could not borrow Balance reference to the Vault")
+
+    return vaultRef.balance
+}

--- a/samples/Cadence/mint_tokens.cdc
+++ b/samples/Cadence/mint_tokens.cdc
@@ -1,0 +1,27 @@
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xTOKENADDRESS
+
+transaction(recipient: Address, amount: UFix64) {
+    let tokenAdmin: &FlowToken.Administrator
+    let tokenReceiver: &{FungibleToken.Receiver}
+
+    prepare(signer: AuthAccount) {
+        self.tokenAdmin = signer
+            .borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)
+            ?? panic("Signer is not the token admin")
+
+        self.tokenReceiver = getAccount(recipient)
+            .getCapability(/public/flowTokenReceiver)
+            .borrow<&{FungibleToken.Receiver}>()
+            ?? panic("Unable to borrow receiver reference")
+    }
+
+    execute {
+        let minter <- self.tokenAdmin.createNewMinter(allowedAmount: amount)
+        let mintedVault <- minter.mintTokens(amount: amount)
+
+        self.tokenReceiver.deposit(from: <-mintedVault)
+
+        destroy minter
+    }
+}

--- a/samples/Cadence/read_profile.cdc
+++ b/samples/Cadence/read_profile.cdc
@@ -1,0 +1,5 @@
+import Profile from 0xProfile
+
+pub fun main(address: Address): Profile.ReadOnly? {
+    return Profile.read(address)
+}

--- a/samples/Cadence/setup_account.cdc
+++ b/samples/Cadence/setup_account.cdc
@@ -1,0 +1,32 @@
+
+// This transaction is a template for a transaction
+// to add a Vault resource to their account
+// so that they can use the flowToken
+
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xTOKENADDRESS
+
+transaction {
+
+    prepare(signer: AuthAccount) {
+
+        if signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) == nil {
+            // Create a new flowToken Vault and put it in storage
+            signer.save(<-FlowToken.createEmptyVault(), to: /storage/flowTokenVault)
+
+            // Create a public capability to the Vault that only exposes
+            // the deposit function through the Receiver interface
+            signer.link<&FlowToken.Vault{FungibleToken.Receiver}>(
+                /public/flowTokenReceiver,
+                target: /storage/flowTokenVault
+            )
+
+            // Create a public capability to the Vault that only exposes
+            // the balance field through the Balance interface
+            signer.link<&FlowToken.Vault{FungibleToken.Balance}>(
+                /public/flowTokenBalance,
+                target: /storage/flowTokenVault
+            )
+        }
+    }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -77,6 +77,7 @@ This is a list of grammars that Linguist selects to provide syntax highlighting 
 - **CSS:** [tree-sitter/tree-sitter-css](https://github.com/tree-sitter/tree-sitter-css) 🐌
 - **CUE:** [cue-sh/vscode-cue](https://github.com/cue-sh/vscode-cue)
 - **Cabal Config:** [atom-haskell/language-haskell](https://github.com/atom-haskell/language-haskell)
+- **Cadence:** [onflow/vscode-cadence](https://github.com/onflow/vscode-cadence)
 - **Cairo:** [xshitaka/atom-language-cairo](https://github.com/xshitaka/atom-language-cairo)
 - **Cap'n Proto:** [textmate/capnproto.tmbundle](https://github.com/textmate/capnproto.tmbundle)
 - **CartoCSS:** [yohanboniface/carto-atom](https://github.com/yohanboniface/carto-atom)

--- a/vendor/licenses/git_submodule/vscode-cadence.dep.yml
+++ b/vendor/licenses/git_submodule/vscode-cadence.dep.yml
@@ -1,0 +1,211 @@
+---
+name: vscode-cadence
+version: ca96897f5d8635d15a41c4ab23db6bc050bcecca
+type: git_submodule
+homepage: https://github.com/onflow/vscode-cadence.git
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright [yyyy] [name of copyright owner]
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+notices: []


### PR DESCRIPTION
## Description
Added the Cadence programming language which is used by the Flow blockchain for its smart contracts. It already is available via VSCode and the Flow community would love to add it to Github. Cadence is used in every decentralized application on Flow which has over 300+ [live projects](https://www.flowverse.co/), a large community (30k+ on [discord](https://discord.gg/mDvccFPx)), and continues to grow in usage both by developers and consumers. Adding this language would make it easier for the community to discovery, browse, and contribute to Flow and Cadence.

## Checklist:

- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com. **Yes**
    - Search results for each extension:
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Acdc
  - [x] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s): 
      - `FlowToken.cdc`: https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowToken.cdc
      - `FlowFees.cdc`: https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowToken.cdc
      - `get_balance.cdc`: https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowToken.cdc
      - `mint_tokens.cdc`: https://github.com/onflow/flow-core-contracts/blob/master/transactions/flowToken/mint_tokens.cdc
      - `setup_account.cdc`: https://github.com/onflow/flow-core-contracts/blob/master/transactions/flowToken/setup_account.cdc
      - `read_profile.cdc`: https://docs.onflow.org/fcl/tutorials/flow-app-quickstart/#querying-the-blockchain
    - Sample license(s): https://github.com/onflow/vscode-cadence/blob/master/LICENSE
  - [x] I have included a syntax highlighting grammar: https://github.com/onflow/vscode-cadence
  - ~~[ ] I have updated the heuristics to distinguish my language from others using the same extension.~~ **NA**
